### PR TITLE
Add LED mode for a one-time sequence of flashes

### DIFF
--- a/led.cpp
+++ b/led.cpp
@@ -32,8 +32,8 @@ led::led(const int ledPin, const int pwmMax) {
  * Uses the fact that odd multiples of half the blink period 
  * should be ON
  *
- * SIGNAL: Uses the same logic as FLASH but only executes one cycle before
- * switching to STOP.
+ * SIGNAL: After the number of flashes * the period of each flash elapses,
+ * 
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */  
 void led::loop() {
 	switch (mode) {
@@ -57,9 +57,9 @@ void led::loop() {
 			break;
 
         case SIGNAL:
-			if (MILLIS - timer >= period * flashes) {
-				mode = STOP;
-			else if ((((MILLIS - timer)) / (period / 2)) % 2)
+			if (MILLIS - timer >= period * flashes)
+				mode  = STOP;
+			else if (((MILLIS - timer) / (period / 2)) % 2)
 				duty = pwmMax;
 			else 
 				duty = 0;
@@ -92,29 +92,30 @@ bool led::isOn() {
 
 
 /* Parameters:
- *	mode		: One of the led modes enumerated in led.h
+ *	mode    : One of the led modes enumerated in led.h
+ *	period  : Period of cyclic functions, in milliseconds 
+ *	flashes : Number of flashes during FLASH mode
+ *	wait    : Time between each burst of flashes in FLASH mode (milliseconds)
+ *	
+ * Effects: Resets timer every time setMode is called
  * * * * * * * * * * * * * * * * * * * * * * */
 void led::setMode(mode_t mode) {
 	setMode(mode, this->period, this->flashes, this->wait);
 }
 
 
-/* Parameters:
- *	mode		: One of the led modes enumerated in led.h
- *	period	: Period of cyclic functions, in milliseconds 
- * * * * * * * * * * * * * * * * * * * * * * */
 void led::setMode(mode_t mode, uint32_t period) {
 	setMode(mode, period, this->flashes, this->wait);
 }
 
 
-/* Parameters:
- *	mode    : One of the led modes enumerated in led.h
- *	period  : Period of cyclic functions, in milliseconds 
- *	flashes : Number of flashes during FLASH mode
- *	wait    : Time between each burst of flashes in FLASH mode (milliseconds)
- * * * * * * * * * * * * * * * * * * * * * * */
+void led::setMode(mode_t mode, uint32_t period, int flashes) {
+	setMode(mode, period, flashes, this->wait);
+}
+
+
 void led::setMode(mode_t mode, uint32_t period, int flashes, uint32_t wait) {
+	timer = MILLIS;
 	this->mode    = mode;
 	this->period  = period;
 	this->flashes = flashes;

--- a/led.cpp
+++ b/led.cpp
@@ -31,25 +31,35 @@ led::led(const int ledPin, const int pwmMax) {
  * 
  * Uses the fact that odd multiples of half the blink period 
  * should be ON
- * **INSERT BELOW**
+ *
+ * SIGNAL: Uses the same logic as FLASH but only executes one cycle before
+ * switching to STOP.
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */  
 void led::loop() {
 	switch (mode) {
 
 		case BLINK:
-			if (MILLIS - timer >= period >> 1) { // Quick divide by 2
+			if (MILLIS - timer >= period / 2) { // Quick divide by 2
 				timer = MILLIS;
 				duty = pwmMax * not duty;
 			}
 			break;
-
 
 		case FLASH:
 			if (MILLIS - timer >= period * flashes + wait)
 				timer = MILLIS;
 			else if (MILLIS - timer >= period * flashes)
 				duty = 0;
-			else if ((((MILLIS - timer)) / (period >> 1)) % 2)
+			else if ((((MILLIS - timer)) / (period / 2)) % 2)
+				duty = pwmMax;
+			else 
+				duty = 0;
+			break;
+
+        case SIGNAL:
+			if (MILLIS - timer >= period * flashes) {
+				mode = STOP;
+			else if ((((MILLIS - timer)) / (period / 2)) % 2)
 				duty = pwmMax;
 			else 
 				duty = 0;

--- a/led.h
+++ b/led.h
@@ -19,6 +19,7 @@
 enum mode_t {
 	BLINK,
 	FLASH,
+    SIGNAL, // Like flash but only runs once then goes to STOP
 	PULSE,
 	SOLID,
 	STOP

--- a/led.h
+++ b/led.h
@@ -35,7 +35,8 @@ class led {
 		 
 		bool isOn();
 		void setMode(mode_t mode);
-		void setMode(mode_t mode, uint32_t period);
+		void setMode(mode_t mode, uint32_t period);		
+		void setMode(mode_t mode, uint32_t period, int flashes);
 		void setMode(mode_t mode, uint32_t period, int flashes, uint32_t wait);
 		void setOff();
 		void phaseInvert();

--- a/main.ino
+++ b/main.ino
@@ -50,10 +50,10 @@ extern uint32_t MILLIS;
 
 
 /* For each test you include, add the corresponding test from loop() */
+#include "testLed.h"
 //#include "testMotor.h"
 //#include "testDrive.h"
-#include "testPathFollow.h"
-
+//#include "testPathFollow.h"
 
 /* High baud rate -> fast printing, to minimize timing impact */
 void setup() { 
@@ -64,7 +64,8 @@ void setup() {
 void loop() {
 	MILLIS = micros() / 1000; 
 
+	testLed();
 	//testMotor();
 	//testDrive();
-	testPathFollow();
+	//testPathFollow();
 }

--- a/testLed.h
+++ b/testLed.h
@@ -1,0 +1,39 @@
+/*
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef TESTLED_H
+#define TESTLED_H
+
+#include <Arduino.h>
+#include "led.h"
+
+extern uint32_t MILLIS;
+
+
+int ledPin = 13; 
+
+led l(ledPin, 127);
+
+
+/*
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void testLed() {
+    static uint32_t timer = MILLIS;
+	static bool     init  = true;
+	if (init) {
+		l.setMode(SIGNAL, 100, 5);
+		init = false;
+	}
+		
+    if (MILLIS - timer >= 3000) {
+        timer = MILLIS;
+        l.setMode(SIGNAL, 100, 5); // 500 ms period, 3 flashes
+    }
+
+    l.loop();
+}
+
+
+#endif


### PR DESCRIPTION
**NOTE** This also changes the behavior of led.setMode(). Every time setMode() is called, it now resets the static timer. 

Pros: 
- Two LEDs whose modes are set one right after the other are guaranteed to be in-sync
- Simplifies the logic for SIGNAL mode
- Helps to know what timer will be when the mode is first set
Cons: 
- The LED won't work if you set its mode repeatedly in a loop, because it will constantly be resetting
- This breaks the logic in testFSM