### PR TITLE
Make all scripts switchable without re-uploading code

### DIFF
--- a/config.h
+++ b/config.h
@@ -23,5 +23,8 @@ const float mtrRightScale =  1.0;
 /* Path sensing */
 const int pathSensePin = A1;
 
+/* Script selection jumper switch */
+const int selectionPin = A2;
+
 
 #endif

--- a/config.h
+++ b/config.h
@@ -1,0 +1,27 @@
+#ifndef BOTPINOUT_H
+#define BOTPINOUT_H
+
+
+/* Thermistor module */
+const int   thermPin           = A0;
+const int   thermLedPin        =  2;
+const float thermDefaultThresh =  0.1; // (V)
+
+/* Light sensing module */
+const int brightSensePin    =  7;
+const int brightSenseLedPin = 12;
+
+/* Motor control pins */
+const int mtrSpeed        = 80;  // Motor base speed. Effective max is 255
+const int mtrLeftFwdPin   =  9;
+const int mtrLeftRevPin   = 10;
+const int mtrRightFwdPin  =  5;
+const int mtrRightRevPin  =  6;
+const float mtrLeftScale  =  1.0;  // NOTE Scaling may change bot-to-bot
+const float mtrRightScale =  1.0;
+
+/* Path sensing */
+const int pathSensePin = A1;
+
+
+#endif

--- a/driveControl.cpp
+++ b/driveControl.cpp
@@ -33,7 +33,7 @@ extern uint32_t MILLIS;
 driveControl::driveControl(int   mtrLeftFwdPin,  int   mtrLeftRevPin,
                            float scaleLeft,      int   mtrRightFwdPin,
                            int   mtrRightRevPin, float scaleRight)
-    : motorLeft(mtrLeftFwdPin, mtrLeftRevPin, scaleLeft),
+    : motorLeft(mtrLeftFwdPin,   mtrLeftRevPin,  scaleLeft),
       motorRight(mtrRightFwdPin, mtrRightRevPin, scaleRight) {
 
     isIdle     = true;

--- a/main.ino
+++ b/main.ino
@@ -51,13 +51,14 @@ extern uint32_t MILLIS;
 //#include "testMotor.h"
 //#include "testDrive.h"
 //#include "testPathFollow.h"
-//#include "testThermistor.h"
+#include "testThermistor.h"
 #include "testBrightSensor.h"
 
 
 /* High baud rate -> fast printing, to minimize timing impact */
 void setup() {
-    Serial.begin(115200);
+   // Serial.begin(115200);
+    Serial.begin(9600);
 }
 
 /* Update MILLIS and call any test function(s) */
@@ -67,6 +68,6 @@ void loop() {
     //testMotor();
     //testDrive();
     //testPathFollow();
-    //testThermistor();
-    testBrightSensor();
+    testThermistor();
+    //testBrightSensor();
 }

--- a/main.ino
+++ b/main.ino
@@ -45,29 +45,66 @@
 #include "globalTimer.h"
 
 extern uint32_t MILLIS;
-
+extern const int selectionPin;
 
 /* For each test you include, add the corresponding test from loop() */
-//#include "testMotor.h"
-//#include "testDrive.h"
-//#include "testPathFollow.h"
+#include "testMotor.h"
+#include "testDrive.h"
+#include "testPathFollow.h"
 #include "testThermistor.h"
 #include "testBrightSensor.h"
+
+void (*scriptFunc)(void) = NULL;
 
 
 /* High baud rate -> fast printing, to minimize timing impact */
 void setup() {
-   // Serial.begin(115200);
-    Serial.begin(9600);
+    Serial.begin(115200);
+
+    int script = analogRead(selectionPin) / 100;
+    Serial.print("Executing Script: ");
+
+    switch (script) {
+        case 10:
+        case  9:
+            Serial.println("testMotor");
+            scriptFunc = testMotor;
+            break;
+
+        case 8: 
+        case 7:
+            Serial.println("testDrive");
+            scriptFunc = testDrive;
+            break;
+
+        case 6: 
+        case 5:
+            Serial.println("testPathFollow");
+            scriptFunc = testPathFollow;
+            break;
+
+        case 4:
+        case 3:
+            Serial.println("testThermistor");
+            scriptFunc = testThermistor;
+            break;
+
+        case 2:
+        case 1:
+            Serial.println("testBrightSensor");
+            scriptFunc = testBrightSensor;
+            break;
+
+        case 0:
+        default:
+            Serial.println("<NO TEST>");
+            scriptFunc = NULL;
+    }
 }
 
 /* Update MILLIS and call any test function(s) */
 void loop() {
     MILLIS = micros() / 1000;
 
-    //testMotor();
-    //testDrive();
-    //testPathFollow();
-    testThermistor();
-    //testBrightSensor();
+    if (scriptFunc != NULL) { scriptFunc(); }
 }

--- a/motorControl.cpp
+++ b/motorControl.cpp
@@ -9,13 +9,13 @@
 extern uint32_t MILLIS;
 
 
-/*
- * Constructor sets direction to FWD and speed to 0
- * and sets pin modes.
- */
-motorControl::motorControl(int fwdPin, int revPin) {
-    initMotor(fwdPin, revPin, 1.0);
-}
+///*
+// * Constructor sets direction to FWD and speed to 0
+// * and sets pin modes.
+// */
+//motorControl::motorControl(int fwdPin, int revPin) {
+//    initMotor(fwdPin, revPin, 1.0);
+//}
 
 
 /*

--- a/motorControl.h
+++ b/motorControl.h
@@ -38,7 +38,8 @@ enum spin_t {
 
 class motorControl {
     public:
-        motorControl(int fwdPin, int revPin);
+        /* Instantiating a motor without scaling value is a deprecated feature */
+        //motorControl(int fwdPin, int revPin);
         motorControl(int fwdPin, int revPin, float scalar);
 
         void loop();

--- a/testBrightSensor.h
+++ b/testBrightSensor.h
@@ -7,22 +7,23 @@
 
 
 #include <Arduino.h>
+#include "config.h"
 #include "brightSensor.h"
 #include "driveControl.h"
 
 extern uint32_t MILLIS;
 
-const int sensorPin  = 7;
-const int ledPin     = 4;
+extern const int brightSensePin;
+extern const int brightSenseLedPin;
 
-const int   mtrLeftFwdPin  = 9;
-const int   mtrLeftRevPin  = 10;
-const int   mtrRightFwdPin = 5;
-const int   mtrRightRevPin = 6;
-const float mtrLeftScale   = 1.0;
-const float mtrRightScale  = 1.0;
+extern const int   mtrLeftFwdPin;
+extern const int   mtrLeftRevPin;
+extern const int   mtrRightFwdPin;
+extern const int   mtrRightRevPin;
+extern const float mtrLeftScale;
+extern const float mtrRightScale;
 
-brightSensor lightFollow(sensorPin, ledPin);
+brightSensor lightFollow(brightSensePin, brightSenseLedPin);
 driveControl botDrive(mtrLeftFwdPin, mtrLeftRevPin, mtrLeftScale,
                       mtrRightFwdPin, mtrRightRevPin, mtrRightScale);
 /*

--- a/testBrightSensor.h
+++ b/testBrightSensor.h
@@ -24,12 +24,14 @@ extern const float mtrLeftScale;
 extern const float mtrRightScale;
 
 brightSensor lightFollow(brightSensePin, brightSenseLedPin);
-driveControl botDrive(mtrLeftFwdPin, mtrLeftRevPin, mtrLeftScale,
-                      mtrRightFwdPin, mtrRightRevPin, mtrRightScale);
+
+
 /*
  *
  */
 void testBrightSensor() {
+    static driveControl botDrive(mtrLeftFwdPin,  mtrLeftRevPin,  mtrLeftScale,
+                                 mtrRightFwdPin, mtrRightRevPin, mtrRightScale);
     static int state = 0;   
  
     lightFollow.loop();

--- a/testDrive.h
+++ b/testDrive.h
@@ -7,14 +7,15 @@
 
 
 #include "Arduino.h"
+#include "config.h"
 #include "driveControl.h"
 
-const int   mtrLeftFwdPin  = 9;
-const int   mtrLeftRevPin  = 10;
-const int   mtrRightFwdPin = 5;
-const int   mtrRightRevPin = 6;
-const float mtrLeftScale   = 1.0;
-const float mtrRightScale  = 1.0;
+extern const int   mtrLeftFwdPin;
+extern const int   mtrLeftRevPin;
+extern const int   mtrRightFwdPin;
+extern const int   mtrRightRevPin;
+extern const float mtrLeftScale;
+extern const float mtrRightScale;
 
 driveControl botDrive(mtrLeftFwdPin, mtrLeftRevPin, mtrLeftScale,
                       mtrRightFwdPin, mtrRightRevPin, mtrRightScale);

--- a/testDrive.h
+++ b/testDrive.h
@@ -17,13 +17,13 @@ extern const int   mtrRightRevPin;
 extern const float mtrLeftScale;
 extern const float mtrRightScale;
 
-driveControl botDrive(mtrLeftFwdPin, mtrLeftRevPin, mtrLeftScale,
-                      mtrRightFwdPin, mtrRightRevPin, mtrRightScale);
 
 /*
  *
  */
 void testDrive() {
+    static driveControl botDrive(mtrLeftFwdPin, mtrLeftRevPin, mtrLeftScale,
+                                 mtrRightFwdPin, mtrRightRevPin, mtrRightScale);
     static int testNum = 0;
 
     botDrive.loop();

--- a/testMotor.h
+++ b/testMotor.h
@@ -7,18 +7,22 @@
 
 
 #include <Arduino.h>
+#include "config.h"
 #include "motorControl.h"
 
 extern uint32_t MILLIS;
 
 
-const int mtrLeftFwdPin  = 4;
-const int mtrLeftRevPin  = 5;
-const int mtrRightFwdPin = 2;
-const int mtrRightRevPin = 3;
+extern const int   mtrLeftFwdPin;
+extern const int   mtrLeftRevPin;
+extern const int   mtrRightFwdPin;
+extern const int   mtrRightRevPin;
+extern const float mtrLeftScale;
+extern const float mtrRightScale;
 
-motorControl leftMotor(mtrLeftFwdPin,   mtrLeftRevPin);
-motorControl rightMotor(mtrRightFwdPin, mtrRightRevPin);
+
+motorControl leftMotor(mtrLeftFwdPin,   mtrLeftRevPin, mtrLeftScale);
+motorControl rightMotor(mtrRightFwdPin, mtrRightRevPin, mtrRightScale);
 
 
 /*

--- a/testPathFollow.h
+++ b/testPathFollow.h
@@ -20,11 +20,11 @@ extern const float mtrLeftScale;
 extern const float mtrRightScale;
 extern const int   mtrSpeed;
 
-driveControl botDrive(mtrLeftFwdPin,  mtrLeftRevPin,  mtrLeftScale,
-                      mtrRightFwdPin, mtrRightRevPin, mtrRightScale);
-
 
 void testPathFollow() {
+    static driveControl botDrive(mtrLeftFwdPin, mtrLeftRevPin, mtrLeftScale,
+                                 mtrRightFwdPin, mtrRightRevPin, mtrRightScale);
+
     static int state = 0;
     static uint32_t timer = MILLIS;
 
@@ -36,9 +36,9 @@ void testPathFollow() {
 
     switch (state) {
 
-        case 0:  // 5s halt
-            botDrive.halt(5000);
-            Serial.println("5s halt...");
+        case 0:  // 1s halt
+            botDrive.halt(1000);
+            Serial.println("1s halt...");
             state = 1;
             break;
 
@@ -81,7 +81,7 @@ void testPathFollow() {
                 botDrive.halt();
                 state = 3;
             } else if (botDrive.getIsIdle()) {
-                botDrive.turnRight(1000, mtrSpeed);
+                botDrive.turnRight(5000, mtrSpeed);
                 Serial.println("Left turn failed, turning right");
                 state = 6;
             }

--- a/testPathFollow.h
+++ b/testPathFollow.h
@@ -7,29 +7,23 @@
 
 #include <Arduino.h>
 #include <limits.h>  // for ULONG_MAX
+#include "config.h"
 #include "driveControl.h"
 
 
-const int   sensorPin      = A1;
-const int   mtrLeftFwdPin  = 9;
-const int   mtrLeftRevPin  = 10;
-const int   mtrRightFwdPin = 5;
-const int   mtrRightRevPin = 6;
-const float mtrLeftScale   = 1.0;
-const float mtrRightScale  = 1.0;
-const int   mtrSpeed       = 80;
+extern const int   pathSensePin;
+extern const int   mtrLeftFwdPin;
+extern const int   mtrLeftRevPin;
+extern const int   mtrRightFwdPin;
+extern const int   mtrRightRevPin;
+extern const float mtrLeftScale;
+extern const float mtrRightScale;
+extern const int   mtrSpeed;
 
 driveControl botDrive(mtrLeftFwdPin,  mtrLeftRevPin,  mtrLeftScale,
                       mtrRightFwdPin, mtrRightRevPin, mtrRightScale);
 
 
-/*
- * SCRIPT:
- * Start forward on black
- * When you hit blue, turn about 90 degrees right (about 1 sec)
- * When you hit yellow, turn a little right
- * When you hit red, stop
- */
 void testPathFollow() {
     static int state = 0;
     static uint32_t timer = MILLIS;
@@ -57,7 +51,7 @@ void testPathFollow() {
             break;
 
         case 2:  // ... until we find the test track
-            if (not digitalRead(sensorPin)) {
+            if (not digitalRead(pathSensePin)) {
                 botDrive.halt();
                 Serial.println("Found black track");
                 state = 3;
@@ -73,7 +67,7 @@ void testPathFollow() {
             break;
 
         case 4:  // ... until we lose the track, in which case we turn to try and find it
-            if (analogRead(sensorPin) >= 400) {
+            if (analogRead(pathSensePin) >= 400) {
                 botDrive.halt();
                 botDrive.turnLeft(500, mtrSpeed);
                 Serial.println("Lost track, turning left");
@@ -82,7 +76,7 @@ void testPathFollow() {
             break;
 
         case 5:  // If we didn't find the track, try turning the other direction; else if we did return to state 3
-            if (analogRead(sensorPin) < 400) {
+            if (analogRead(pathSensePin) < 400) {
                 Serial.println("Left turn successful");
                 botDrive.halt();
                 state = 3;
@@ -94,7 +88,7 @@ void testPathFollow() {
             break;
 
         case 6:  // If we still can't find the track, give up!
-            if (analogRead(sensorPin) < 400) {
+            if (analogRead(pathSensePin) < 400) {
                 Serial.println("Right turn successful");
                 botDrive.halt();
                 state = 3;

--- a/testThermistor.h
+++ b/testThermistor.h
@@ -7,14 +7,15 @@
 
 #include <Arduino.h>
 #include <limits.h>  // for ULONG_MAX
+#include "config.h"
 #include "thermistor.h"
 
-const int  sensorPin      = A5;
-const int  outLedPin      = 7;
-
+extern const int   thermPin;
+extern const int   thermLedPin;
+extern const float thermDefaultThresh;
 
 void testThermistor() {
-  thermistor thermObject(sensorPin, outLedPin);
+  thermistor thermObject(thermPin, thermLedPin, thermDefaultThresh);
   
   thermObject.init();
   thermObject.checkFirstValue();

--- a/thermistor.cpp
+++ b/thermistor.cpp
@@ -8,19 +8,20 @@
 
 extern uint32_t MILLIS;
 
-/*
+
+/*  
  *
  */
-thermistor::thermistor(int sensorPinIn, int outputPinIn) {
-    sensorPin = sensorPinIn;
-    outputPin = outputPinIn;
-    thermThreshold = 0.1; // (V)
+thermistor::thermistor(int sensorPin, int outputPin, float thermThreshold) {
+    this->sensorPin = sensorPin;
+    this->outputPin = outputPin;
+    this->thermThreshold = thermThreshold; // (V)
 }
 
 /*
  *
  */
-void thermistor::init(){
+void thermistor::init() {
   pinMode(sensorPin, INPUT_PULLUP);
   pinMode(outputPin, OUTPUT);
 }
@@ -28,12 +29,11 @@ void thermistor::init(){
 /*
  *
  */
-void thermistor::loop(){
-  while(true){
+void thermistor::loop() {
+  while (true) {
     checkCurrentValue();
 
-    if ((currThermVoltage - firstThermVoltage) > thermThreshold)
-    {
+    if ((currThermVoltage - firstThermVoltage) > thermThreshold) {
       digitalWrite(outputPin, HIGH);
     }
   }
@@ -42,7 +42,7 @@ void thermistor::loop(){
 /*
  *
  */
-void thermistor::checkFirstValue(){
+void thermistor::checkFirstValue() {
   currThermValue = analogRead(sensorPin);
   firstThermVoltage = currThermValue * (5.0 / 1023);
 }

--- a/thermistor.h
+++ b/thermistor.h
@@ -9,10 +9,10 @@
 
 #include <Arduino.h>
 
-class thermistor{
+class thermistor {
   public:
 
-    thermistor(int sensorPinIn, int outputPinIn);
+    thermistor(int sensorPinIn, int outputPinIn, float thermThreshold);
   
     void init();
     void loop();


### PR DESCRIPTION
**NOTE:** the relevant commit is mis-titled. I put "no-reboot" but it should be "no-upload". You do have to hit the reset button to change scripts, but you don't have to plug in or anything.

I used a function pointer during `setup()` so there's no additional processing needed during the main loop.

Currently there are 6 voltage options going into pin A2: 0, 1, 2, 3, 4, and 5 volts. I take the analog input value /100 and use "transparent" cases in such a way that rounding is not a problem.

I have testMotor on 5V, testDrive on 4V, testPathFollow on 3V, testThermistor on 2V, testBrightSensor on 1V, and "<NO TEST>" on 0V. (The test name gets printed to serial during `setup`.

In order to make this compile I had to move some object instantiations in the scripts from being globals to being static locals. Otherwise `botDrive` gets multiply defined. Makes no difference in practice, but it's probably better to have them local anyway.